### PR TITLE
Fix RDB snapshot save location

### DIFF
--- a/internal/core/server/server.go
+++ b/internal/core/server/server.go
@@ -123,7 +123,7 @@ func (s *Server) Shutdown() {
 	}
 
 	if s.config.UseRDB {
-		rdb.SaveSnapshot(s.store, "dump.rdb")
+		rdb.SaveSnapshot(s.store, filepath.Join(s.dataDir, "dump.rdb"))
 	}
 }
 


### PR DESCRIPTION
Save the RDB snapshot in the configured data directory instead of the default location.