### PR TITLE
Update Go version in Dockerfile and simplify docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build stage
-FROM golang:1.23-alpine AS builder
+FROM golang:1.25-alpine AS builder
 
 # Install make
 RUN apk add --no-cache make git

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3.8'
 
 services:
   goodiesdb-server:


### PR DESCRIPTION
Upgrade the Go version in the Dockerfile to 1.25 and remove versioning from the docker-compose file for simplicity.